### PR TITLE
It would be greatly helpful if we can update the rspec version to 2.14.0...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gemspec
-gem 'rspec', '~> 2.13.0'
+gem 'rspec', '~> 2.14.0'
 gem 'nokogiri', '~> 1.6.0'
 gem 'mimemagic'

--- a/allure-rspec.gemspec
+++ b/allure-rspec.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'rspec', '~> 2.13.0'
+  s.add_dependency 'rspec', '~> 2.14.0'
   s.add_dependency 'nokogiri', '~> 1.6.0'
   s.add_dependency 'uuid'
   s.add_dependency 'mimemagic'


### PR DESCRIPTION
... and above. We are trying to use the gem for our api and ui automation to generate reports with screenshots attached. So it would be greatly helpful if you can support later versions of rspec as well! I ran the specs and it worked as expected.
