### PR TITLE
version bumps for dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    allure-rspec (0.7.4)
-      allure-ruby-adaptor-api (= 0.6.9)
+    allure-rspec (0.8.0)
+      allure-ruby-adaptor-api (= 0.7.0)
       rspec (~> 3.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    allure-ruby-adaptor-api (0.6.9)
+    allure-ruby-adaptor-api (0.7.0)
       mimemagic
       nokogiri (~> 1.6.0)
       uuid

--- a/allure-rspec.gemspec
+++ b/allure-rspec.gemspec
@@ -11,15 +11,15 @@ Gem::Specification.new do |s|
   s.description   = %q{Adaptor to use Allure framework along with the RSpec 2}
   s.summary       = "allure-rspec-#{AllureRSpec::Version::STRING}"
   s.homepage      = 'http://allure.qatools.ru'
-  s.license       = 'Apache2'
+  s.license       = 'Apache-2.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'rspec', '~> 3.2'
-  s.add_dependency 'allure-ruby-adaptor-api', '0.6.9'
+  s.add_dependency 'rspec', '~> 3.5'
+  s.add_dependency 'allure-ruby-adaptor-api', '0.7'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'

--- a/lib/allure-rspec/formatter.rb
+++ b/lib/allure-rspec/formatter.rb
@@ -8,7 +8,7 @@ module AllureRSpec
 
     NOTIFICATIONS = [:example_group_started, :example_group_finished, :example_started,
                      :example_failed, :example_passed, :example_pending, :start, :stop]
-    ALLOWED_LABELS = [:feature, :story, :severity, :language, :framework]
+    ALLOWED_LABELS = [:feature, :story, :severity, :language, :framework, :host]
 
     def example_failed(notification)
       res = notification.example.execution_result

--- a/lib/allure-rspec/formatter.rb
+++ b/lib/allure-rspec/formatter.rb
@@ -8,7 +8,7 @@ module AllureRSpec
 
     NOTIFICATIONS = [:example_group_started, :example_group_finished, :example_started,
                      :example_failed, :example_passed, :example_pending, :start, :stop]
-    ALLOWED_LABELS = [:feature, :story, :severity, :language, :framework, :host]
+    ALLOWED_LABELS = [:feature, :story, :severity, :language, :framework]
 
     def example_failed(notification)
       res = notification.example.execution_result

--- a/lib/allure-rspec/version.rb
+++ b/lib/allure-rspec/version.rb
@@ -1,5 +1,5 @@
 module AllureRSpec # :nodoc:
   module Version # :nodoc:
-    STRING = '0.7.5'
+    STRING = '0.8.0'
   end
 end


### PR DESCRIPTION
allure-ruby-adaptor-api version 0.7.0 - fixing nokogiri (2.4.0 Fixnum depreciation)
rspec to latest
Gemfile.lock updated to match gemspec